### PR TITLE
feature: add goqright generate subcommand

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generates a predefined automated task",
+	Long: `The "generate" command runs a predefined automated task designed for a specific use case. 
+	
+This command must be extended with extra flags to include a custom logic.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("generate called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// generateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// generateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}


### PR DESCRIPTION
**Outline of solution**
- Created the subcommand generate for the root command goqright

usage : 
goqright --help
<img width="923" alt="Screenshot 2025-03-14 at 12 33 12 PM" src="https://github.com/user-attachments/assets/f60d7e67-5cb9-41c4-92a8-26bd06e1b1db" />


goqright generate --help
<img width="801" alt="Screenshot 2025-03-14 at 12 34 01 PM" src="https://github.com/user-attachments/assets/457758af-1471-4b1f-bd5e-3d03b8531092" />